### PR TITLE
Add `mocha` and `should` to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
   "devDependencies": {
     "coffee-script": "*",
     "express": "*",
-    "chai": "*"
+    "chai": "*",
+    "mocha": "*",
+    "should": "*"
   },
   "scripts": {
     "prepublish": "cake build"


### PR DESCRIPTION
These packages are used in testing, so it makes sense to list them as developmental dependencies.
