### PR TITLE
Sending "authorization":"undefined" causes basic authentication modules to return a 400 instead of 401.

### DIFF
--- a/main.coffee
+++ b/main.coffee
@@ -35,13 +35,10 @@ class exports.JsonClient
 
     # Send a GET request to path. Parse response body to obtain a JS object.
     get: (path, callback, parse = true) ->
-        header = {'accept': 'application/json'}
-        if @auth?
-            header["authorization"] = @auth
-        if @agent?
-            header["user-agent"] = @agent
-        if @token?
-            header["x-auth-token"] = @token
+        header = accept: 'application/json'
+        header["authorization"] = @auth if @auth?
+        header["user-agent"] = @agent if @agent?
+        header["x-auth-token"] = @token if @token?
         request
             method: 'GET'
             headers: header


### PR DESCRIPTION
Sending "authorization":"undefined" causes basic authentication modules to return a 400 instead of 401.

So, I added some undefined checks that verify that the headers are defined before stuffing them in the request.
