### PR TITLE
Allow passing of options to the underlying request library.

### DIFF
--- a/main.coffee
+++ b/main.coffee
@@ -86,7 +86,6 @@ class exports.JsonClient
         options = @options
         options.method = "DELETE"
         options.uri = url.resolve @host, path
-        options.json = json
         options.headers = @headers
 
         request options, (error, response, body) ->


### PR DESCRIPTION
This library is super great for making working with well behaved JSON endpoints simpler. Super useful.

I've just ran into an issue where I'm talking to one that isn't so nice, and it's SSL cert isn't set up quite right. The request library supports an option to turn strict ssl validation off, but there's no way to set that option using this lib. Rather than special case it, I figured we could allow users to optionally pass an extra options argument to the constructor.

It's a non-breaking change, so we keep the lovely simple usability of this module, but get back a bunch of the power of the underlying lib for use-cases like mine, with only a few additional LOC.

We try not to clobber the users supplied options unless it makes sense to (so the convenience http verb methods should override any 'method' option passed to the constructor). I've also only allowed settings passed to the constructor, so it only really makes sense for 'global' type settings - you could argue the specific methods could also take an options argument - but I didn't need that and it would have made this an even bigger pull request.

Let me know if this is a wanted change - we certainly needed it, and it would be nice to not have to abandon the convenience of the module altogether just because we need to set that SSL option.
