### PR TITLE
Added support for HTTP PATCH method

### DIFF
--- a/main.coffee
+++ b/main.coffee
@@ -81,6 +81,19 @@ class exports.JsonClient
             else callback error, response, body
 
 
+    # Send a PATCH request to path with given JSON as body.
+    patch: (path, json, callback, parse = true) ->
+        options = @options
+        options.method = "PATCH"
+        options.uri = url.resolve @host, path
+        options.json = json
+        options.headers = @headers
+
+        request options, (error, response, body) ->
+            if parse then parseBody error, response, body, callback
+            else callback error, response, body
+
+
     # Send a DELETE request to path.
     del: (path, callback, parse = true) ->
         options = @options

--- a/tests.coffee
+++ b/tests.coffee
@@ -116,6 +116,29 @@ describe "Common requests", ->
             @response.statusCode.should.be.equal 200
 
 
+    describe "client.patch", ->
+
+        before ->
+            @serverPatch = fakeServer msg:"ok", 200, (body, req) ->
+                should.exist body.patchData
+                req.method.should.equal "PATCH"
+                req.url.should.equal  "/test-path/123"
+            @serverPatch.listen 8888
+            @client = request.newClient "http://localhost:8888/"
+
+        after ->
+            @serverPatch.close()
+
+
+        it "When I send patch request to server", (done) ->
+            @client.patch "test-path/123", patchData: "data test", (error, response, body) =>
+                @response = response
+                done()
+
+        it "Then I get 200 as answer", ->
+            @response.statusCode.should.be.equal 200
+
+
     describe "client.del", ->
 
         before ->


### PR DESCRIPTION
The PATCH method was [published as an RFC](http://tools.ietf.org/html/rfc5789) in 2010 and is now in use by some REST APIs (e.g. [ArangoDB](https://www.arangodb.org/manuals/current/RestDocument.html)) to supplement the PUT method (although the exact semantics are often implementation-specific).

I've added a corresponding method and a test case. The behaviour is analogous to PUT.
