### PR TITLE
Force JSON parsing of response when sending a GET request

### DIFF
--- a/main.coffee
+++ b/main.coffee
@@ -74,6 +74,7 @@ class exports.JsonClient
             options = {}
         opts = buildOptions @options, @headers, @host, path, options
         opts.method = 'GET'
+        opts.json = true
 
         request opts, (error, response, body) ->
             if parse then parseBody error, response, body, callback


### PR DESCRIPTION
Without this line, body is returned as a string. This line forces request to parse the body as a JSON and return an object.
