### PR TITLE
Updating request dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "main": "./main.js",
   "dependencies": {
-    "request": "2.34.0"
+    "request": "2.45.0"
   },
   "devDependencies": {
     "coffee-script": "1.7.1",


### PR DESCRIPTION
This latest version of `request` includes a fix for file uploads not sending content-length correctly. File uploads fail on some servers (e.g. IIS / ASP.NET) as "bad request."
