### PR TITLE
Document headers feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ client.get('private/posts/', function(err, res, body) {
 
 ```
 
+### Extra: Headers manipulation
+
+```javascript
+client.headers['Cookie'] = 'Your cookie';
+```
+
 ## Who uses it
 
 request-json and request-json-light are downloaded more than 8000 times each


### PR DESCRIPTION
Related to the issue #36.

`request-json` offers the capability to change the client headers, but it wasn't documented in the README file.