### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,12 +11,7 @@
     "simple",
     "utility"
   ],
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/mycozycloud/request-json/blob/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "version": "0.5.3",
   "homepage": "https://github.com/mycozycloud/request-json/",
   "bugs": {


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/