### PR TITLE
Add tests.coffee to the lint script. Fix up lint errors with the tests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "prepublish": "./node_modules/coffee-script/bin/coffee -cb main.coffee",
     "test": "mocha tests.coffee --reporter spec --compilers coffee:coffee-script/register --colors",
     "build": "./node_modules/coffee-script/bin/coffee -cb main.coffee",
-    "lint": "./node_modules/coffeelint/bin/coffeelint main.coffee"
+    "lint": "./node_modules/coffeelint/bin/coffeelint main.coffee tests.coffee"
   },
   "repository": {
     "type": "git",

--- a/tests.coffee
+++ b/tests.coffee
@@ -21,7 +21,7 @@ fakeServer = (json, code=200, callback=null) ->
             res.end(JSON.stringify json)
 
 fakeServerRaw = (code, out) ->
-     http.createServer (req, res) ->
+    http.createServer (req, res) ->
         req.on 'data', (chunk) ->
         req.on 'end', ->
             res.writeHead code


### PR DESCRIPTION
#51 

@frankrousseau As an extension of this, what's your opinion on adding the lint checker to the CI process as a pre-build step?