### PR TITLE
Added support for digest authentication

### DIFF
--- a/main.coffee
+++ b/main.coffee
@@ -75,6 +75,12 @@ class requestJson.JsonClient
         basicCredentials = new Buffer(credentials).toString('base64')
         @headers["authorization"] = "Basic #{basicCredentials}"
 
+    # Set digest auth
+    setDigestAuth: (username, password) ->
+        @options.auth =
+            user: username
+            pass: password
+            sendImmediately: false
 
     # Add a token to request header.
     setToken: (token) ->

--- a/main.coffee
+++ b/main.coffee
@@ -71,9 +71,9 @@ class requestJson.JsonClient
 
     # Set basic authentication on each requests
     setBasicAuth: (username, password) ->
-        credentials = "#{username}:#{password}"
-        basicCredentials = new Buffer(credentials).toString('base64')
-        @headers["authorization"] = "Basic #{basicCredentials}"
+        @options.auth =
+            user: username
+            pass: password
 
     # Set digest auth
     setDigestAuth: (username, password) ->
@@ -88,7 +88,7 @@ class requestJson.JsonClient
 
     # Add OAuth2 Bearer token to request header.
     setBearerToken: (token) ->
-        @headers["authorization"] = "Bearer #{token}"
+        @options.auth = bearer: token
 
     # Send a GET request to path. Parse response body to obtain a JS object.
     get: (path, options, callback, parse = true) ->

--- a/tests.coffee
+++ b/tests.coffee
@@ -60,6 +60,41 @@ fakePutServer = (url, dir, callback= -> ) ->
             unless err
                 res.send 201
 
+fakeServerWithDigestAuth = (json, code=200, callback= -> ) ->
+    http.createServer (req, res) ->
+        isAuthorized = false
+        body = ""
+        req.on 'data', (chunk) ->
+            body += chunk
+        req.on 'end', ->
+            ok = false
+
+            if req.headers.authorization
+                reg = RegExp '^' + ([].join.call [
+                    'Digest username="john"'
+                    'realm="testrealm@host.com"'
+                    'nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093"'
+                    'uri="/test-path/"'
+                    'response="3432c8a013c25be4770c271d63ec96a9"',
+                ], ', ') + '$'
+                if reg.test req.headers.authorization
+                    ok = true
+                else
+                    ok = false
+
+            if ok
+                callback(body, req)
+                res.writeHead code, 'Content-Type': 'application/json'
+                res.end(JSON.stringify json)
+            else
+                res.setHeader "WWW-Authenticate", [].join.call [
+                    'Digest realm="testrealm@host.com"'
+                    'nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093"'
+                ], ', '
+
+                res.statusCode = 401
+                res.end('401')
+
 
 describe "Common requests", ->
 
@@ -559,6 +594,33 @@ describe "Basic authentication", ->
         it "Then I get msg: ok as answer.", ->
             should.exist @body.msg
             @body.msg.should.equal "ok"
+
+
+describe "Digest authentication", ->
+
+    before ->
+        @serverGet = fakeServerWithDigestAuth msg:"ok", 200, (body, req) =>
+            console.log JSON.stringify req.headers
+            should.exist req.headers.authorization
+            req.method.should.equal "GET"
+            req.url.should.equal  "/test-path/"
+        @serverGet.listen 8888
+        @client = request.createClient "http://localhost:8888/"
+
+    after ->
+        @serverGet.close()
+
+    it "When I send get request to server", (done) ->
+        @client.setDigestAuth "john", "secret"
+        @client.get "test-path/", (error, response, body) =>
+            should.not.exist error
+            response.statusCode.should.be.equal 200
+            @body = body
+            done()
+
+    it "Then I get msg: ok as answer.", ->
+        should.exist @body.msg
+        @body.msg.should.equal "ok"
 
 
 describe "Set token", ->

--- a/tests.coffee
+++ b/tests.coffee
@@ -48,7 +48,7 @@ rawBody = (req, res, next) ->
     req.rawBody = ''
     req.on 'data', (chunk) ->
         req.rawBody += chunk
-    req.on 'end', () ->
+    req.on 'end', ->
         next()
 
 fakePutServer = (url, dir, callback= -> ) ->
@@ -686,7 +686,8 @@ describe "Set OAuth2 bearer token", ->
         before ->
             @serverGet = fakeServer msg:"ok", 200, (body, req) ->
                 bearerToken = req.headers['authorization']
-                bearerToken.should.equal 'Bearer cozy' # Check that the bearer prefix has been added
+                # Check that the bearer prefix has been added
+                bearerToken.should.equal 'Bearer cozy'
                 req.method.should.equal "GET"
                 req.url.should.equal "/test-path/"
             @serverGet.listen 8888


### PR DESCRIPTION
Refers to issue #24.

Usage: `client.setDigestAuth(username, password)`

The function passes the credentials directly through to the request object. This means it maintains feature/implementation parity with the request library, which is a bit patchy; 2 out of 3 servers I tested against worked. 
There is a TODO to complete the implementation: https://github.com/request/request/blob/master/lib/auth.js#L52

I also attached an extra commit to the pull request (3e790e7) to switch two other auth methods to use the functionality provided by request rather than reimplementing them. Let me know if you want me to remove that commit.