### PR TITLE
Allow to parse response after a file upload + gzip test

### DIFF
--- a/main.coffee
+++ b/main.coffee
@@ -128,17 +128,17 @@ class requestJson.JsonClient
 
     # Send a POST request to path with given JSON as body.
     post: (path, json, options, callback, parse = true) ->
-        @handleRequest 'POST', path, json, options, callback
+        @handleRequest 'POST', path, json, options, callback, parse
 
 
     # Send a PUT request to path with given JSON as body.
     put: (path, json, options, callback, parse = true) ->
-        @handleRequest 'PUT', path, json, options, callback
+        @handleRequest 'PUT', path, json, options, callback, parse
 
 
     # Send a PATCH request to path with given JSON as body.
     patch: (path, json, options, callback, parse = true) ->
-        @handleRequest 'PATCH', path, json, options, callback
+        @handleRequest 'PATCH', path, json, options, callback, parse
 
 
     # Send a HEAD request to path. Expect no response body.
@@ -148,7 +148,7 @@ class requestJson.JsonClient
 
     # Send a DELETE request to path.
     del: (path, options, callback, parse = true) ->
-        @handleRequest 'DELETE', path, null, options, callback
+        @handleRequest 'DELETE', path, null, options, callback, parse
 
 
     # Alias for del
@@ -161,9 +161,12 @@ class requestJson.JsonClient
     # Use a read stream for that.
     # If you use a stream, it must have a "path" attribute...
     # ...with its path or filename
-    sendFile: (path, files, data, callback) ->
-        callback = data if typeof(data) is "function"
-        req = @post path, null, callback, false #do not parse
+    sendFile: (path, files, data, callback, parse = false) ->
+        if typeof(data) is "function"
+            callback = data
+            parse = callback
+
+        req = @post path, null, callback, parse
 
         form = req.form()
         unless typeof(data) is "function"
@@ -193,9 +196,12 @@ class requestJson.JsonClient
     # Use a read stream for that.
     # If you use a stream, it must have a "path" attribute...
     # ...with its path or filename
-    putFile: (path, file, data, callback) ->
-        callback = data if typeof(data) is "function"
-        req = @put path, null, callback, false #do not parse
+    putFile: (path, file, data, callback, parse=false) ->
+        if typeof(data) is "function"
+            parse = callback or false
+            callback = data
+
+        req = @put path, null, {}, callback, parse
 
         # file is a string so it is a file path
         if typeof file is "string"

--- a/package.json
+++ b/package.json
@@ -38,17 +38,17 @@
   "main": "./main.js",
   "dependencies": {
     "depd": "1.1.0",
-    "request": "2.72.0"
+    "request": "2.74.0"
   },
   "devDependencies": {
-    "body-parser": "1.15.0",
+    "body-parser": "1.15.2",
     "chai": "3.5.0",
     "coffee-script": "1.10.0",
     "coffeelint": "1.15.7",
     "connect-multiparty": "2.0.0",
-    "express": "4.13.4",
-    "lie": "3.0.4",
-    "mocha": "2.4.5"
+    "express": "4.14.0",
+    "lie": "3.1.0",
+    "mocha": "2.5.3"
   },
   "scripts": {
     "prepublish": "./node_modules/coffee-script/bin/coffee -cb main.coffee",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "utility"
   ],
   "license": "MIT",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "homepage": "https://github.com/mycozycloud/request-json/",
   "bugs": {
     "url": "https://github.com/mycozycloud/request-json/issues"

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "chai": "3.5.0",
     "coffee-script": "1.10.0",
     "coffeelint": "1.15.7",
+    "compression": "1.6.2",
     "connect-multiparty": "2.0.0",
     "express": "4.14.0",
     "lie": "3.1.0",


### PR DESCRIPTION
Hello,

I made a fix for the #50 issue. It simply allows to parse response when a file is uploaded.

I added a test for gzipped response parsing (#58). Everything seems to work fine. So, I didn't commit any fix for this.

Regards,

Frank Rousseau